### PR TITLE
Focus on add task input field removed

### DIFF
--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -18,7 +18,6 @@ body {
   line-height: 1.2;
   color: $black;
   background-color: $dirtyWhite;
-  overflow: hidden;
 }
 
 h1 {

--- a/src/components/modules/AddTask.vue
+++ b/src/components/modules/AddTask.vue
@@ -26,10 +26,6 @@ export default {
       newTask: null,
     };
   },
-  mounted() {
-    const ele = this.$refs.addTask__input;
-    ele.focus();
-  },
   methods: {
     ...mapActions([
       'addNewTask',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -50,6 +50,69 @@ const store = createStore({
           },
         ],
       },
+      {
+        name: 'List 3',
+        id: 3,
+        todos: [
+          {
+            id: 1,
+            title: 'Learn Mocha',
+            completed: false,
+          },
+          {
+            id: 2,
+            title: 'Learn Sinon',
+            completed: false,
+          },
+          {
+            id: 3,
+            title: 'Learn Karma',
+            completed: true,
+          },
+        ],
+      },
+      {
+        name: 'List 4',
+        id: 4,
+        todos: [
+          {
+            id: 1,
+            title: 'Learn Mocha',
+            completed: false,
+          },
+          {
+            id: 2,
+            title: 'Learn Sinon',
+            completed: false,
+          },
+          {
+            id: 3,
+            title: 'Learn Karma',
+            completed: true,
+          },
+        ],
+      },
+      {
+        name: 'List 5',
+        id: 5,
+        todos: [
+          {
+            id: 1,
+            title: 'Learn Mocha',
+            completed: false,
+          },
+          {
+            id: 2,
+            title: 'Learn Sinon',
+            completed: false,
+          },
+          {
+            id: 3,
+            title: 'Learn Karma',
+            completed: true,
+          },
+        ],
+      },
     ],
   },
   getters: rootGetters,


### PR DESCRIPTION
# Hotfix

## Issue  #fixed
- Whenever we load the site and multiple list were present, then at that time focus was getting set to the last list and page was automatically getting scroll down to that list which was not the intended behaviour of the site.
- Scrollbar was hidden in the site which was making the critical content unavailable to the user.

#37 
